### PR TITLE
refactor(gcp): remove gws-docs-query alias and rely on module bin path

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ TODO: Add a short summary of this module.
 - `p6df::modules::gcp::deps()`
 - `p6df::modules::gcp::external::brew()`
 - `p6df::modules::gcp::home::symlink()`
-- `p6df::modules::gcp::init(_module, dir)`
 - `p6df::modules::gcp::langs()`
 - `p6df::modules::gcp::path::init()`
 - `str str = p6df::modules::gcp::prompt::mod()`

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ TODO: Add a short summary of this module.
 
 ##### p6df-gcp/init.zsh
 
-- `p6df::modules::gcp::aliases::init()`
 - `p6df::modules::gcp::completions::init()`
 - `p6df::modules::gcp::deps()`
 - `p6df::modules::gcp::external::brew()`
 - `p6df::modules::gcp::home::symlink()`
+- `p6df::modules::gcp::init(_module, dir)`
 - `p6df::modules::gcp::langs()`
 - `p6df::modules::gcp::path::init()`
 - `str str = p6df::modules::gcp::prompt::mod()`

--- a/init.zsh
+++ b/init.zsh
@@ -15,26 +15,6 @@ p6df::modules::gcp::deps() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::gcp::init(_module, dir)
-#
-#  Args:
-#	_module -
-#	dir -
-#
-#>
-######################################################################
-p6df::modules::gcp::init() {
-  local _module="$1"
-  local dir="$2"
-
-  p6_bootstrap "$dir"
-
-  p6_return_void
-}
-
-######################################################################
-#<
-#
 # Function: p6df::modules::gcp::external::brew()
 #
 #>

--- a/init.zsh
+++ b/init.zsh
@@ -15,6 +15,26 @@ p6df::modules::gcp::deps() {
 ######################################################################
 #<
 #
+# Function: p6df::modules::gcp::init(_module, dir)
+#
+#  Args:
+#	_module -
+#	dir -
+#
+#>
+######################################################################
+p6df::modules::gcp::init() {
+  local _module="$1"
+  local dir="$2"
+
+  p6_bootstrap "$dir"
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
 # Function: p6df::modules::gcp::external::brew()
 #
 #>
@@ -83,21 +103,6 @@ p6df::modules::gcp::path::init() {
 p6df::modules::gcp::completions::init() {
 
   p6_file_load "$HOMEBREW_PREFIX/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/completion.zsh.inc"
-}
-
-######################################################################
-#<
-#
-# Function: p6df::modules::gcp::aliases::init()
-#
-#  Environment:	 P6_DFZ_SRC_DIR
-#>
-######################################################################
-p6df::modules::gcp::aliases::init() {
-
-  p6_alias "gws-docs-query" "$P6_DFZ_SRC_DIR/p6m7g8-dotfiles/p6df-gcp/bin/gws-docs-query"
-
-  p6_return_void
 }
 
 ######################################################################


### PR DESCRIPTION
## Summary
- remove `p6df::modules::gcp::aliases::init()` for `gws-docs-query`
- keep command discovery via standard module `bin/` path behavior in the existing framework
- update README function list accordingly

## Validation
- `bash -n init.zsh`
