### PR TITLE
fix(gcp): mirror awscdk init so module bin is on PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ TODO: Add a short summary of this module.
 - `p6df::modules::gcp::deps()`
 - `p6df::modules::gcp::external::brew()`
 - `p6df::modules::gcp::home::symlink()`
+- `p6df::modules::gcp::init(_module, dir)`
 - `p6df::modules::gcp::langs()`
 - `p6df::modules::gcp::path::init()`
 - `str str = p6df::modules::gcp::prompt::mod()`

--- a/init.zsh
+++ b/init.zsh
@@ -15,6 +15,26 @@ p6df::modules::gcp::deps() {
 ######################################################################
 #<
 #
+# Function: p6df::modules::gcp::init(_module, dir)
+#
+#  Args:
+#	_module -
+#	dir -
+#
+#>
+######################################################################
+p6df::modules::gcp::init() {
+  local _module="$1"
+  local dir="$2"
+
+  p6_bootstrap "$dir"
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
 # Function: p6df::modules::gcp::external::brew()
 #
 #>


### PR DESCRIPTION
## Summary
- mirror `p6df-awscdk` module pattern by adding `p6df::modules::gcp::init(_module, dir)`
- call `p6_bootstrap "$dir"` so `p6df-gcp/bin` is added to PATH by the existing framework
- keep framework unchanged; this is module-local behavior

## Validation
- `bash -n init.zsh`
