### PR TITLE
fix(gcp): make gws-docs-query lib safe to source

### DIFF
--- a/lib/gws-docs-query.sh
+++ b/lib/gws-docs-query.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -euo pipefail
 
 p6df::modules::gcp::gws_docs_query::usage() {
   cat <<'USAGE'


### PR DESCRIPTION
## Summary
- remove `set -euo pipefail` from `lib/gws-docs-query.sh`
- the file is sourced via `p6_bootstrap`, so global shell options must not be mutated there
- keeps strict mode in executable `bin/gws-docs-query`

## Validation
- `bash -n lib/gws-docs-query.sh`
- `zsh -lc 'unset P6_PREFIX P6_DFZ_PROMPT_IN_VSCODE; source lib/gws-docs-query.sh'`
