### PR TITLE
feat: add mcp() hook with mcp-toolbox

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: Build
 
 on:
   pull_request: {}
+  merge_group: {}
   workflow_dispatch: {}
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@
 
 ## Summary
 
-TODO: Add a short summary of this module.
+p6df module for Google Cloud Platform: `gcloud` SDK, Google Workspace CLI,
+prompt integration, and MCP server (`mcp-toolbox` via brew, Google's official
+GenAI Toolbox for databases: BigQuery, Cloud SQL, Spanner).
 
 ## Contributing
 
@@ -40,22 +42,24 @@ TODO: Add a short summary of this module.
 - `p6df::modules::gcp::external::brew()`
 - `p6df::modules::gcp::home::symlink()`
 - `p6df::modules::gcp::init(_module, dir)`
+  - Args:
+    - _module
+    - dir
 - `p6df::modules::gcp::langs()`
+- `p6df::modules::gcp::mcp()`
 - `p6df::modules::gcp::path::init()`
 - `str str = p6df::modules::gcp::prompt::mod()`
-
-#### p6df-gcp/bin
-
-##### p6df-gcp/bin/gws-docs-query
-
-- `gws-docs-query [options] <search text>`
 
 #### p6df-gcp/lib
 
 ##### p6df-gcp/lib/gws-docs-query.sh
 
+- `p6df::modules::gcp::gws_docs_query::main(limit, owner, ...)`
+  - Args:
+    - limit
+    - owner
+    - ...
 - `p6df::modules::gcp::gws_docs_query::usage()`
-- `p6df::modules::gcp::gws_docs_query::main()`
 
 ## Hierarchy
 

--- a/init.zsh
+++ b/init.zsh
@@ -9,6 +9,7 @@
 p6df::modules::gcp::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6df-go
+    p6m7g8-dotfiles/p6df-js
   )
 }
 
@@ -42,6 +43,7 @@ p6df::modules::gcp::init() {
 p6df::modules::gcp::external::brew() {
 
   p6df::core::homebrew::cli::brew::install --cask google-cloud-sdk
+  p6_js_npm_global_install "@googleworkspace/cli"
 
   p6_return_void
 }
@@ -149,3 +151,17 @@ p6df::modules::gcp::prompt::mod() {
 # gcloud projects list
 # gcloud projects describe p6m7g8
 # gcloud configure-docker # Docker credential helper
+
+######################################################################
+#<
+#
+# Function: p6df::modules::gcp::mcp()
+#
+#>
+######################################################################
+p6df::modules::gcp::mcp() {
+
+  p6df::core::homebrew::cli::brew::install mcp-toolbox
+
+  p6_return_void
+}

--- a/lib/gws-docs-query.sh
+++ b/lib/gws-docs-query.sh
@@ -1,11 +1,18 @@
 #!/usr/bin/env bash
 
+######################################################################
+#<
+#
+# Function: p6df::modules::gcp::gws_docs_query::usage()
+#
+#>
+######################################################################
 p6df::modules::gcp::gws_docs_query::usage() {
   cat <<'USAGE'
 Usage:
   gws-docs-query [options] <search text>
 
-Search Google Workspace Docs (Google Docs files) via Drive API.
+Search Google Docs files via the Google Workspace CLI (`gws`) Drive API.
 
 Options:
   -n, --limit <N>        Max results (default: 20)
@@ -18,11 +25,28 @@ Examples:
 USAGE
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::gcp::gws_docs_query::main(limit, owner, ...)
+#
+#  Args:
+#	limit -
+#	owner -
+#	... - 
+#
+#  Environment:	 GWS_BIN
+#>
+######################################################################
 p6df::modules::gcp::gws_docs_query::main() {
-  local gcloud_bin
-  gcloud_bin="${GCLOUD_BIN:-$(command -v gcloud || true)}"
-  if [[ -z "$gcloud_bin" ]]; then
-    echo "gcloud not found. Install with: brew install --cask google-cloud-sdk" >&2
+  local gws_bin
+  gws_bin="${GWS_BIN:-$(command -v gws || true)}"
+  if [[ -z "$gws_bin" ]]; then
+    cat <<'MSG' >&2
+gws not found.
+Install with:
+  npm install -g @googleworkspace/cli
+MSG
     return 1
   fi
 
@@ -56,38 +80,36 @@ p6df::modules::gcp::gws_docs_query::main() {
 
   local search_text="$*"
 
-  if ! "$gcloud_bin" auth list --format='value(account)' | grep -q .; then
+  local auth_status auth_method
+  auth_status="$("$gws_bin" auth status 2>/dev/null || true)"
+  auth_method="$(echo "$auth_status" | jq -r '.auth_method // "none"' 2>/dev/null)"
+  if [[ "$auth_method" == "none" ]]; then
     cat <<'MSG' >&2
-No gcloud account is logged in.
+gws is not authenticated.
 Run one of these first:
-  gcloud auth login --enable-gdrive-access
+  gws auth setup
+  gws auth login
 MSG
     return 1
   fi
 
-  local access_token
-  access_token="$("$gcloud_bin" auth print-access-token)"
-
   local q
-  q="mimeType='application/vnd.google-apps.document' and trashed=false and fullText contains '${search_text//\'/\\\'}'"
+  q="mimeType=\"application/vnd.google-apps.document\" and trashed=false and fullText contains \"${search_text//\"/\\\"}\""
   if [[ -n "$owner" ]]; then
-    q="$q and '${owner//\'/\\\'}' in owners"
+    q="$q and \"${owner//\"/\\\"}\" in owners"
   fi
 
-  local enc_q
-  enc_q="$(python3 - <<PY
-import urllib.parse
-print(urllib.parse.quote("""$q"""))
-PY
-)"
+  local params resp
+  params="$(jq -cn \
+    --arg q "$q" \
+    --arg fields "files(id,name,webViewLink,modifiedTime,owners(displayName,emailAddress))" \
+    --arg orderBy "modifiedTime desc" \
+    --argjson pageSize "$limit" \
+    '{q: $q, pageSize: $pageSize, fields: $fields, orderBy: $orderBy}')"
 
-  local url
-  url="https://www.googleapis.com/drive/v3/files?q=${enc_q}&pageSize=${limit}&fields=files(id,name,webViewLink,modifiedTime,owners(displayName,emailAddress))&orderBy=modifiedTime%20desc"
+  resp="$("$gws_bin" drive files list --format json --params "$params")"
 
-  local resp
-  resp="$(curl -sS -H "Authorization: Bearer ${access_token}" "$url")"
-
-  if echo "$resp" | jq -e '.error' >/dev/null; then
+  if echo "$resp" | jq -e '.error' >/dev/null 2>&1; then
     echo "$resp" | jq . >&2
     return 1
   fi


### PR DESCRIPTION
## Summary
- Adds `p6df::modules::gcp::mcp()` installing `mcp-toolbox` via brew (Google's official GenAI Toolbox for databases: BigQuery, Cloud SQL, Spanner)
- Adds `@googleworkspace/cli` to `external::brew()` and `p6df-js` to deps
- Updates `gws-docs-query` to use `gws` CLI instead of `gcloud` directly
- Regenerated README with updated function list and Summary

## Test plan
- [ ] `p6df::modules::gcp::mcp()` installs `mcp-toolbox`

🤖 Generated with [Claude Code](https://claude.com/claude-code)