### PR TITLE
fix: remove brackets from gcp prompt string

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -127,7 +127,7 @@ p6df::modules::gcp::prompt::mod() {
     fi
   fi
 
-  p6_return_str "gcp:\t\t  [${account}${project:+|$project}${quota_str}${age_str}]"
+  p6_return_str "gcp:\t\t  ${account}${project:+|$project}${quota_str}${age_str}"
 }
 
 ######################################################################


### PR DESCRIPTION
## Summary

- Removes surrounding brackets from GCP prompt return string

## Test plan

- [ ] GCP prompt displays without brackets
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)