### PR TITLE
fix: rename external::brew() -> external::brews() to match framework dispatch

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -36,11 +36,11 @@ p6df::modules::gcp::init() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::gcp::external::brew()
+# Function: p6df::modules::gcp::external::brews()
 #
 #>
 ######################################################################
-p6df::modules::gcp::external::brew() {
+p6df::modules::gcp::external::brews() {
 
   p6df::core::homebrew::cli::brew::install --cask google-cloud-sdk
   p6df::core::homebrew::cli::brew::install oauth2l


### PR DESCRIPTION
## Summary
- Rename `external::brew()` → `external::brews()` to match the plural form dispatched by `p6df-core/lib/module.zsh`

## Test plan
- [ ] Verify `p6df::core::module::brews` dispatch resolves correctly