### PR TITLE
chore(init): reorder hooks per hook_api.md lifecycle order

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -1,5 +1,11 @@
 # shellcheck shell=bash
 ######################################################################
+#<
+#
+# Function: p6df::modules::gcp::deps()
+#
+#>
+######################################################################
 p6df::modules::gcp::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6df-go
@@ -7,6 +13,13 @@ p6df::modules::gcp::deps() {
   )
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::gcp::path::init()
+#
+#  Environment:	 HOMEBREW_PREFIX
+#>
 ######################################################################
 p6df::modules::gcp::path::init() {
 
@@ -18,6 +31,12 @@ p6df::modules::gcp::path::init() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::gcp::external::brews()
+#
+#>
+######################################################################
 p6df::modules::gcp::external::brews() {
 
   p6df::core::homebrew::cli::brew::install --cask google-cloud-sdk
@@ -27,6 +46,12 @@ p6df::modules::gcp::external::brews() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::gcp::langs()
+#
+#>
+######################################################################
 p6df::modules::gcp::langs() {
 
   gcloud components install anthoscli beta
@@ -34,6 +59,12 @@ p6df::modules::gcp::langs() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::gcp::mcp()
+#
+#>
 ######################################################################
 p6df::modules::gcp::mcp() {
 
@@ -47,31 +78,6 @@ p6df::modules::gcp::mcp() {
 
   p6_return_void
 }
-######################################################################
-#<
-#
-# Function: p6df::modules::gcp::deps()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::gcp::external::brews()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::gcp::langs()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::gcp::path::init()
-#
-#  Environment:	 HOMEBREW_PREFIX
-#>
 ######################################################################
 #<
 #
@@ -125,9 +131,3 @@ p6df::modules::gcp::prompt::context() {
   p6_return_str "$(p6_string_space_pad "gcp:" 16)${account}${project:+|$project}${quota_str}${age_str}"
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::gcp::mcp()
-#
-#>

--- a/init.zsh
+++ b/init.zsh
@@ -1,11 +1,5 @@
 # shellcheck shell=bash
 ######################################################################
-#<
-#
-# Function: p6df::modules::gcp::deps()
-#
-#>
-######################################################################
 p6df::modules::gcp::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6df-go
@@ -13,42 +7,6 @@ p6df::modules::gcp::deps() {
   )
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::gcp::external::brews()
-#
-#>
-######################################################################
-p6df::modules::gcp::external::brews() {
-
-  p6df::core::homebrew::cli::brew::install --cask google-cloud-sdk
-  p6df::core::homebrew::cli::brew::install oauth2l
-
-  p6_return_void
-}
-
-######################################################################
-#<
-#
-# Function: p6df::modules::gcp::langs()
-#
-#>
-######################################################################
-p6df::modules::gcp::langs() {
-
-  gcloud components install anthoscli beta
-
-  p6_return_void
-}
-
-######################################################################
-#<
-#
-# Function: p6df::modules::gcp::path::init()
-#
-#  Environment:	 HOMEBREW_PREFIX
-#>
 ######################################################################
 p6df::modules::gcp::path::init() {
 
@@ -59,6 +17,61 @@ p6df::modules::gcp::path::init() {
   p6_return_void
 }
 
+######################################################################
+p6df::modules::gcp::external::brews() {
+
+  p6df::core::homebrew::cli::brew::install --cask google-cloud-sdk
+  p6df::core::homebrew::cli::brew::install oauth2l
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::gcp::langs() {
+
+  gcloud components install anthoscli beta
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::gcp::mcp() {
+
+  # Workspace APIs (Drive, Gmail, Calendar, Sheets, Docs, Chat, etc.) are
+  # covered by the gws CLI — no MCP server needed for those.
+  # mcp-toolbox is only needed for Cloud SQL / AlloyDB / Spanner tooling.
+  p6df::core::homebrew::cli::brew::install mcp-toolbox
+
+  p6df::modules::anthropic::mcp::server::add "gcp" "mcp-toolbox"
+  p6df::modules::openai::mcp::server::add "gcp" "mcp-toolbox"
+
+  p6_return_void
+}
+######################################################################
+#<
+#
+# Function: p6df::modules::gcp::deps()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::gcp::external::brews()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::gcp::langs()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::gcp::path::init()
+#
+#  Environment:	 HOMEBREW_PREFIX
+#>
 ######################################################################
 #<
 #
@@ -118,16 +131,3 @@ p6df::modules::gcp::prompt::context() {
 # Function: p6df::modules::gcp::mcp()
 #
 #>
-######################################################################
-p6df::modules::gcp::mcp() {
-
-  # Workspace APIs (Drive, Gmail, Calendar, Sheets, Docs, Chat, etc.) are
-  # covered by the gws CLI — no MCP server needed for those.
-  # mcp-toolbox is only needed for Cloud SQL / AlloyDB / Spanner tooling.
-  p6df::core::homebrew::cli::brew::install mcp-toolbox
-
-  p6df::modules::anthropic::mcp::server::add "gcp" "mcp-toolbox"
-  p6df::modules::openai::mcp::server::add "gcp" "mcp-toolbox"
-
-  p6_return_void
-}


### PR DESCRIPTION
## What
Reorder hook functions in `init.zsh` to match the canonical lifecycle order defined in `p6df-core/doc/hook_api.md`.

**Lifecycle:** `deps → init → env::init → path::init → cdpath::init → fpath::init → completions::init → aliases::init → langmgr::init → prompt::init`

**Install-time:** `home::symlinks → external::brews → langs → mcp → vscodes → vscodes::config`

**Profile:** `profile::on → profile::off → profile::mod → prompt::mod::bottom`

## Why
Hook functions were defined in inconsistent order across modules. Enforcing the canonical order makes the files easier to audit and ensures the documented execution sequence is visually obvious.

## Test plan
- [ ] Verified hook order with automated check (all pass)
- [ ] No functional changes — only block reordering

## Dependencies
None