### PR TITLE
feat(gcp): add args to path::init, rename prompt::mod to prompt::context, remove workspace lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,18 +35,15 @@ TODO: Add a short summary of this module.
 
 ##### p6df-gcp/init.zsh
 
-- `p6df::modules::gcp::completions::init()`
 - `p6df::modules::gcp::deps()`
-- `p6df::modules::gcp::external::brew()`
-- `p6df::modules::gcp::home::symlink()`
-- `p6df::modules::gcp::init(_module, dir)`
-  - Args:
-    - _module
-    - dir
+- `p6df::modules::gcp::external::brews()`
 - `p6df::modules::gcp::langs()`
 - `p6df::modules::gcp::mcp()`
-- `p6df::modules::gcp::path::init()`
-- `str config = p6df::modules::gcp::prompt::mod()`
+- `p6df::modules::gcp::path::init(_module, _dir)`
+  - Args:
+    - _module
+    - _dir
+- `str config = p6df::modules::gcp::prompt::context()`
 
 #### p6df-gcp/lib
 
@@ -76,177 +73,6 @@ TODO: Add a short summary of this module.
 - `str {project} = p6df::modules::gcp::config::project::get()`
 - `str {project} = p6df::modules::gcp::config::quota_project::get()`
 
-##### p6df-gcp/lib/workspace.sh
-
-- `p6df::modules::gcp::workspace::delegation::setup(delegated_email)`
-  - Args:
-    - delegated_email
-- `p6df::modules::gcp::workspace::dwd::admin::get(sa_key_file, email)`
-  - Args:
-    - sa_key_file
-    - email
-- `p6df::modules::gcp::workspace::dwd::admin::groups::get(sa_key_file, email)`
-  - Args:
-    - sa_key_file
-    - email
-- `p6df::modules::gcp::workspace::dwd::admin::orgunits::get(sa_key_file, email)`
-  - Args:
-    - sa_key_file
-    - email
-- `p6df::modules::gcp::workspace::dwd::admin::reports::audit::get(sa_key_file, email)`
-  - Args:
-    - sa_key_file
-    - email
-- `p6df::modules::gcp::workspace::dwd::admin::reports::usage::get(sa_key_file, email)`
-  - Args:
-    - sa_key_file
-    - email
-- `p6df::modules::gcp::workspace::dwd::all::get(sa_key_file, email)`
-  - Args:
-    - sa_key_file
-    - email
-- `p6df::modules::gcp::workspace::dwd::analytics::get(sa_key_file, email)`
-  - Args:
-    - sa_key_file
-    - email
-- `p6df::modules::gcp::workspace::dwd::calendar::get(sa_key_file, email)`
-  - Args:
-    - sa_key_file
-    - email
-- `p6df::modules::gcp::workspace::dwd::chat::get(sa_key_file, email)`
-  - Args:
-    - sa_key_file
-    - email
-- `p6df::modules::gcp::workspace::dwd::chat::memberships::get(sa_key_file, email)`
-  - Args:
-    - sa_key_file
-    - email
-- `p6df::modules::gcp::workspace::dwd::chat::spaces::get(sa_key_file, email)`
-  - Args:
-    - sa_key_file
-    - email
-- `p6df::modules::gcp::workspace::dwd::classroom::coursework::get(sa_key_file, email)`
-  - Args:
-    - sa_key_file
-    - email
-- `p6df::modules::gcp::workspace::dwd::classroom::get(sa_key_file, email)`
-  - Args:
-    - sa_key_file
-    - email
-- `p6df::modules::gcp::workspace::dwd::classroom::rosters::get(sa_key_file, email)`
-  - Args:
-    - sa_key_file
-    - email
-- `p6df::modules::gcp::workspace::dwd::contacts::get(sa_key_file, email)`
-  - Args:
-    - sa_key_file
-    - email
-- `p6df::modules::gcp::workspace::dwd::docs::get(sa_key_file, email)`
-  - Args:
-    - sa_key_file
-    - email
-- `p6df::modules::gcp::workspace::dwd::drive::get(sa_key_file, email)`
-  - Args:
-    - sa_key_file
-    - email
-- `p6df::modules::gcp::workspace::dwd::forms::get(sa_key_file, email)`
-  - Args:
-    - sa_key_file
-    - email
-- `p6df::modules::gcp::workspace::dwd::gmail::get(sa_key_file, email)`
-  - Args:
-    - sa_key_file
-    - email
-- `p6df::modules::gcp::workspace::dwd::meet::get(sa_key_file, email)`
-  - Args:
-    - sa_key_file
-    - email
-- `p6df::modules::gcp::workspace::dwd::sheets::get(sa_key_file, email)`
-  - Args:
-    - sa_key_file
-    - email
-- `p6df::modules::gcp::workspace::dwd::slides::get(sa_key_file, email)`
-  - Args:
-    - sa_key_file
-    - email
-- `p6df::modules::gcp::workspace::dwd::tasks::get(sa_key_file, email)`
-  - Args:
-    - sa_key_file
-    - email
-- `p6df::modules::gcp::workspace::dwd::vault::get(sa_key_file, email)`
-  - Args:
-    - sa_key_file
-    - email
-- `str {token} = p6df::modules::gcp::workspace::admin::get(email)`
-  - Args:
-    - email
-- `str {token} = p6df::modules::gcp::workspace::admin::groups::get(email)`
-  - Args:
-    - email
-- `str {token} = p6df::modules::gcp::workspace::admin::orgunits::get(email)`
-  - Args:
-    - email
-- `str {token} = p6df::modules::gcp::workspace::admin::reports::audit::get(email)`
-  - Args:
-    - email
-- `str {token} = p6df::modules::gcp::workspace::admin::reports::usage::get(email)`
-  - Args:
-    - email
-- `str {token} = p6df::modules::gcp::workspace::analytics::get(email)`
-  - Args:
-    - email
-- `str {token} = p6df::modules::gcp::workspace::calendar::get(email)`
-  - Args:
-    - email
-- `str {token} = p6df::modules::gcp::workspace::chat::get(email)`
-  - Args:
-    - email
-- `str {token} = p6df::modules::gcp::workspace::chat::memberships::get(email)`
-  - Args:
-    - email
-- `str {token} = p6df::modules::gcp::workspace::chat::spaces::get(email)`
-  - Args:
-    - email
-- `str {token} = p6df::modules::gcp::workspace::classroom::coursework::get(email)`
-  - Args:
-    - email
-- `str {token} = p6df::modules::gcp::workspace::classroom::get(email)`
-  - Args:
-    - email
-- `str {token} = p6df::modules::gcp::workspace::classroom::rosters::get(email)`
-  - Args:
-    - email
-- `str {token} = p6df::modules::gcp::workspace::contacts::get(email)`
-  - Args:
-    - email
-- `str {token} = p6df::modules::gcp::workspace::docs::get(email)`
-  - Args:
-    - email
-- `str {token} = p6df::modules::gcp::workspace::drive::get(email)`
-  - Args:
-    - email
-- `str {token} = p6df::modules::gcp::workspace::forms::get(email)`
-  - Args:
-    - email
-- `str {token} = p6df::modules::gcp::workspace::gmail::get(email)`
-  - Args:
-    - email
-- `str {token} = p6df::modules::gcp::workspace::meet::get(email)`
-  - Args:
-    - email
-- `str {token} = p6df::modules::gcp::workspace::sheets::get(email)`
-  - Args:
-    - email
-- `str {token} = p6df::modules::gcp::workspace::slides::get(email)`
-  - Args:
-    - email
-- `str {token} = p6df::modules::gcp::workspace::tasks::get(email)`
-  - Args:
-    - email
-- `str {token} = p6df::modules::gcp::workspace::vault::get(email)`
-  - Args:
-    - email
-
 ## Hierarchy
 
 ```text
@@ -254,11 +80,10 @@ TODO: Add a short summary of this module.
 ├── init.zsh
 ├── lib
 │   ├── auth.sh
-│   ├── config.sh
-│   └── workspace.sh
+│   └── config.sh
 └── README.md
 
-2 directories, 5 files
+2 directories, 4 files
 ```
 
 ## Author

--- a/init.zsh
+++ b/init.zsh
@@ -16,7 +16,11 @@ p6df::modules::gcp::deps() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::gcp::path::init()
+# Function: p6df::modules::gcp::path::init(_module, _dir)
+#
+#  Args:
+#	_module -
+#	_dir -
 #
 #  Environment:	 HOMEBREW_PREFIX
 #>
@@ -86,7 +90,7 @@ p6df::modules::gcp::mcp() {
 #  Returns:
 #	str - config
 #	str - 
-#	str - $(p6_string_space_pad "gcp:" 16)${account}${project:+|$project}${quota_str}${age_str}
+#	str - (p6_string_space_pad 
 #
 #  Environment:	 HOME
 #>


### PR DESCRIPTION
**What:** Add `_module`/`_dir` args to `path::init`, rename `prompt::mod` to `prompt::context`, remove workspace lib documentation, remove `completions::init` and `home::symlink` from README

**Why:** Aligns function signatures with the established naming convention; workspace lib was removed; cleans up stale function references in documentation

**Test plan:** Source the module and verify `p6df::modules::gcp::path::init` and `p6df::modules::gcp::prompt::context` work correctly

**Dependencies:** none